### PR TITLE
Use recommendation from brew warning output

### DIFF
--- a/Formula/conway.rb
+++ b/Formula/conway.rb
@@ -7,7 +7,7 @@ class Conway < Formula
 
   bottle :unneeded
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     bin.install "conway" => "conway"


### PR DESCRIPTION
```
$ brew install beyond-curl
==> Installing beyond-curl from square/formula
==> Downloading https://nexus3.sqcorp.co/repository/raw-square-homebrew/square/bottles/beyond-curl-0.1.7.catalina.bottle.tar.gz
######################################################################## 100.0%
==> Pouring beyond-curl-0.1.7.catalina.bottle.tar.gz
🍺  /usr/local/Cellar/beyond-curl/0.1.7: 4 files, 5.7MB
Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the alecstrong/repo tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/alecstrong/homebrew-repo/Formula/conway.rb:10
```