### PR TITLE
Remove deprecated command

### DIFF
--- a/Formula/conway.rb
+++ b/Formula/conway.rb
@@ -5,8 +5,6 @@ class Conway < Formula
   sha256 "56fa6b692e108c24e7b145cb2a59dfae11972e56d44b687de6a2accfa7705374"
   head "https://github.com/alecstrong/conway.git"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the alecstrong/repo tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/alecstrong/homebrew-repo/Formula/conway.rb:8
```